### PR TITLE
[skip changelog] fix: changelog形式をシンプルに & skip機能追加

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-changelog:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true && !contains(github.event.pull_request.title, '[skip changelog]')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -21,25 +21,27 @@ jobs:
 
       - name: Update CHANGELOG.md
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           MERGE_DATE: ${{ github.event.pull_request.merged_at }}
         run: |
           # Format the date (YYYY-MM-DD)
           FORMATTED_DATE=$(date -d "$MERGE_DATE" '+%Y-%m-%d' 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$MERGE_DATE" '+%Y-%m-%d' 2>/dev/null || echo "$MERGE_DATE" | cut -d'T' -f1)
 
-          # Create the new entry
-          NEW_ENTRY="## [$FORMATTED_DATE] PR #$PR_NUMBER\n\n- **$PR_TITLE** by @$PR_AUTHOR\n  - $PR_URL\n"
+          # Escape special characters for sed
+          ESCAPED_TITLE=$(echo "$PR_TITLE" | sed 's/[&/\]/\\&/g')
+          ESCAPED_URL=$(echo "$PR_URL" | sed 's/[&/\]/\\&/g')
+
+          # Create the new entry (simple format with link)
+          NEW_ENTRY="- $FORMATTED_DATE: [$ESCAPED_TITLE]($ESCAPED_URL)"
 
           # Insert the new entry after the marker
-          sed -i "s|<!-- CHANGELOG_MARKER -->|<!-- CHANGELOG_MARKER -->\n\n$NEW_ENTRY|" CHANGELOG.md
+          sed -i "s|<!-- CHANGELOG_MARKER -->|<!-- CHANGELOG_MARKER -->\n$NEW_ENTRY|" CHANGELOG.md
 
       - name: Commit and push changes
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
-          git diff --staged --quiet || git commit -m "docs: update changelog for PR #${{ github.event.pull_request.number }}"
+          git diff --staged --quiet || git commit -m "docs: update changelog for PR #${{ github.event.pull_request.number }} [skip changelog]"
           git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,4 @@
-# 更新履歴
-
-このドキュメントは、マージされたPRに基づいて自動更新されます。
+### 更新履歴
 
 <!-- CHANGELOG_MARKER -->
-
-## [2026-01-19] PR #4
-
-- **fix: 生成仮定→生成過程のtypo修正 <!-- CHANGELOG_MARKER --> changelog自動更新機能追加** by @ikuo-suyama
-  - https://github.com/ikuo-suyama/bayes-to-friston-free-energy/pull/4
-
+- 2026-01-19: [fix: 生成仮定→生成過程のtypo修正](https://github.com/ikuo-suyama/bayes-to-friston-free-energy/pull/4)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+## コントリビューション
+
+誤りや改善点があればIssueやPRをお気軽にどうぞ。
+
+### 更新履歴について
+
+PRがマージされると、自動的に[CHANGELOG.md](./CHANGELOG.md)が更新されます。
+
+記事に関係しない変更（CI修正など）の場合は、PRタイトルに `[skip changelog]` を含めてください。
+
+例: `[skip changelog] chore: CI設定修正`

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 ベイズ推論からFristonの自由エネルギー原理への道筋を解説するブログ記事。
 
 https://note.com/martin_lover/n/nb28438c22a6e
+
+## コントリビューション
+
+[CONTRIBUTING.md](./CONTRIBUTING.md)を参照してください。


### PR DESCRIPTION
## Summary

- CHANGELOG.mdの形式をNoteに貼り付けやすいシンプルな形式に変更
- `[skip changelog]` 機能を追加

## Changes

### 形式変更
Before:
```markdown
## [2026-01-19] PR #4

- **PRタイトル** by @author
  - URL
```

After:
```markdown
- 2026-01-19: [PRタイトル](URL)
```

### Skip機能
PRタイトルに `[skip changelog]` を含めると更新をスキップ

### バグ修正
- `&` などの特殊文字がsedで壊れる問題を修正
- changelog更新コミット自体が無限ループしないよう `[skip changelog]` を自動付与