### PR TITLE
[skip changelog] fix: HTMLコメントマーカーを削除

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -37,8 +37,8 @@ jobs:
           # Create the new entry
           NEW_ENTRY="- $FORMATTED_DATE: [$ESCAPED_TITLE]($ESCAPED_URL)"
 
-          # Insert the new entry after the marker
-          sed -i "s|<!-- CHANGELOG_MARKER -->|<!-- CHANGELOG_MARKER -->\n$NEW_ENTRY|" "$ARTICLE"
+          # Insert the new entry after "### 更新履歴"
+          sed -i "/^### 更新履歴$/a $NEW_ENTRY" "$ARTICLE"
 
       - name: Commit and push changes
         run: |

--- a/ベイズの定理からFristonの自由エネルギー原理へ.md
+++ b/ベイズの定理からFristonの自由エネルギー原理へ.md
@@ -705,5 +705,4 @@ $$
 （初版：2026-01-15）
 
 ### 更新履歴
-<!-- CHANGELOG_MARKER -->
 - 2026-01-19: [生成仮定→生成過程のtypo修正](https://github.com/ikuo-suyama/bayes-to-friston-free-energy/pull/4)


### PR DESCRIPTION
## Summary

`<!-- CHANGELOG_MARKER -->` がNoteでコメントとして扱われないため削除。

代わりに `### 更新履歴` の直後に挿入するよう変更。