### PR TITLE
fix: 改版履歴の自動更新がマージ後に動作しない問題を修正 [skip changelog]

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -35,8 +35,10 @@ jobs:
           # Create the new entry
           NEW_ENTRY="- $FORMATTED_DATE: [$ESCAPED_TITLE]($ESCAPED_URL)"
 
-          # Get all .md files that were modified (not added) in this PR
-          git diff --name-only --diff-filter=M origin/main...HEAD | grep '\.md$' | while read -r file; do
+          # Get all .md files that were modified (not added) in the merge commit
+          # HEAD^1 is the first parent (main branch before merge)
+          # HEAD is the merge commit
+          git diff --name-only --diff-filter=M HEAD^1 HEAD | grep '\.md$' | while read -r file; do
             # Check if the file has a changelog section
             if [ -f "$file" ] && grep -q "^## 更新履歴$" "$file"; then
               echo "Updating changelog in: $file"

--- a/ベイズの定理からFristonの自由エネルギー原理へ.md
+++ b/ベイズの定理からFristonの自由エネルギー原理へ.md
@@ -826,6 +826,7 @@ $$
 
 
 ## 更新履歴
+- 2026-01-22: [セクション5に最適化の同値性を明示的に追加](https://github.com/ikuo-suyama/bayes-to-friston-free-energy/pull/15)
 - 2026-01-21: [feat: 周辺尤度と正規化定数の関係を付録2として追加](https://github.com/ikuo-suyama/bayes-to-friston-free-energy/pull/12)
 - 2026-01-20: [fix: 尤度とエビデンスの対比を段階的に説明](https://github.com/ikuo-suyama/bayes-to-friston-free-energy/pull/9)
 - 2026-01-19: [生成仮定→生成過程のtypo修正](https://github.com/ikuo-suyama/bayes-to-friston-free-energy/pull/4)


### PR DESCRIPTION
## 概要

PR #15で改版履歴が自動更新されなかった問題を修正します。

## 問題

ワークフローが以下の理由で更新履歴を追加できませんでした：

1. **差分検出の問題**: `git diff --name-only --diff-filter=M origin/main...HEAD` を使用
2. **原因**: `ref: main` でチェックアウトしているため、マージ後では `origin/main` と `HEAD` が同じコミットを指している
3. **結果**: "Everything up-to-date" となり、何も変更が検出されなかった

## 修正内容

1. **ワークフローの修正**:
   - `git diff --name-only --diff-filter=M HEAD^1 HEAD` を使用
   - `HEAD^1` はマージ前のmainブランチ
   - `HEAD` はマージコミット
   - これによりマージによって変更されたファイルを正しく検出

2. **手動での更新履歴追加**:
   - PR #15の更新履歴エントリを手動で追加

## テスト計画

- [ ] このPRをマージして、次のPRで改版履歴が正しく自動更新されることを確認
- [ ] ワークフローログで "Updating changelog in:" メッセージが表示されることを確認
- [ ] コミットが正しく作成されることを確認

## 参考

- 失敗したワークフロー実行: https://github.com/ikuo-suyama/bayes-to-friston-free-energy/actions/runs/21250581598/job/61150810359