### PR TITLE
fix: 日本語ファイル名に対応するようchangelog更新ワークフローを修正 [skip changelog]

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -35,6 +35,9 @@ jobs:
           # Create the new entry
           NEW_ENTRY="- $FORMATTED_DATE: [$ESCAPED_TITLE]($ESCAPED_URL)"
 
+          # Configure git to not quote non-ASCII characters in filenames
+          git config core.quotePath false
+
           # Get all .md files that were modified (not added) in the merge commit
           # HEAD^1 is the first parent (main branch before merge)
           # HEAD is the merge commit

--- a/ベイズの定理からFristonの自由エネルギー原理へ.md
+++ b/ベイズの定理からFristonの自由エネルギー原理へ.md
@@ -834,6 +834,7 @@ $$
 
 
 ## 更新履歴
+- 2026-01-24: [統計力学との対応セクションの改善](https://github.com/ikuo-suyama/bayes-to-friston-free-energy/pull/17)
 - 2026-01-22: [セクション5に最適化の同値性を明示的に追加](https://github.com/ikuo-suyama/bayes-to-friston-free-energy/pull/15)
 - 2026-01-21: [feat: 周辺尤度と正規化定数の関係を付録2として追加](https://github.com/ikuo-suyama/bayes-to-friston-free-energy/pull/12)
 - 2026-01-20: [fix: 尤度とエビデンスの対比を段階的に説明](https://github.com/ikuo-suyama/bayes-to-friston-free-energy/pull/9)


### PR DESCRIPTION
## Summary
- GitHub Actionsワークフローで日本語ファイル名が正しく検出されない問題を修正
- `git config core.quotePath false`を追加し、非ASCII文字がクォートされないように設定
- PR #17の更新履歴を手動で追加

## 問題の原因
`git diff --name-only`の出力で、日本語ファイル名が8進数表現（`"\343\203\231..."`）になっていたため、`grep '\.md$'`がマッチしていませんでした。

## Test plan
- [ ] 次回のPRマージ時に、更新履歴が自動的に追加されることを確認